### PR TITLE
Remove max timeout for aiohttp

### DIFF
--- a/ososedki_dl/utils.py
+++ b/ososedki_dl/utils.py
@@ -23,7 +23,7 @@ from rich.prompt import Prompt
 from .consts import CACHE_PATH, CHECK_CACHE, MAX_TIMEOUT
 
 ua = UserAgent(min_version=120.0)
-client_timeout = ClientTimeout(total=MAX_TIMEOUT)
+client_timeout = ClientTimeout()
 
 
 def get_valid_url() -> list:
@@ -203,7 +203,7 @@ async def download_and_compare(
         return {"url": url, "status": f"error: {e}"}
     except Exception as e:
         print(f"Failed to fetch {url} with error {e}")
-        return {"url": url, "status": "error"}
+        return {"url": url, "status": f"error: {e}"}
 
     if media_path.exists():
         file_content: bytes = media_path.read_bytes()


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->

Closes #24

## 📑 Description

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

Problem originated in commit https://github.com/YisusChrist/ososedki_dl/commit/79931d06c91c3e142851ca2e738d6138e2451e79

Setting the max timeout on the ClientTimeout to 5 seconds causes problems with the multiple concurrent requests made by aiohttp. This is becasue the limit set is very restrictive when the requests volum is high.

By removing the ClientTimeout argument allows it to take the default value (5 minutes).

More information at https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientTimeout

## ✅ Checks

<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
