### PR TITLE
Add missing site paths on ososedki-based crawlers

### DIFF
--- a/ososedki_dl/crawlers/ososedki/cosplayasian.py
+++ b/ososedki_dl/crawlers/ososedki/cosplayasian.py
@@ -7,7 +7,7 @@ class CosplayAsianCrawler(OsosedkiBaseCrawler):
     site_url = "https://cosplayasian.com"
     base_image_path = "/images/a/"
     album_path = "/post/"
-    model_url = None
+    model_url = f"{site_url}/mod/"
     cosplay_url = f"{site_url}/cos/"
     button_class = None
     pagination = True

--- a/ososedki_dl/crawlers/ososedki/cosplaythots.py
+++ b/ososedki_dl/crawlers/ososedki/cosplaythots.py
@@ -7,7 +7,7 @@ class CosplayThotsCrawler(OsosedkiBaseCrawler):
     site_url = "https://cosplaythots.com"
     base_image_path = "/images/a/"
     album_path = "/p/"
-    model_url = None
+    model_url = f"{site_url}/m/"
     cosplay_url = f"{site_url}/c/"
     button_class = None
     pagination = True

--- a/ososedki_dl/crawlers/ososedki/vipthots.py
+++ b/ososedki_dl/crawlers/ososedki/vipthots.py
@@ -7,7 +7,7 @@ class VipThotsCrawler(OsosedkiBaseCrawler):
     site_url = "https://vipthots.com"
     base_image_path = "/images/a/"
     album_path = "/p/"
-    model_url = None
-    cosplay_url = None
-    button_class = None
+    model_url = f"{site_url}/m/"
+    cosplay_url = f"{site_url}/c/"
+    button_class = "btn btn-sm bg-model"
     pagination = True


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->

Closes #193

## 📑 Description

<!-- Add a brief description of the pr -->

Enhance the functionality of ososedki-based crawlers by adding support for the `/cosplay` and `/model` paths for the CosplayAsian, CosplayThots, and VipThots sites. Update the model and cosplay URLs accordingly and set the button class for the VipThots crawler to facilitate album title extraction.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks

<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->

- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
