### PR TITLE
[eromexxx]: Fix media scraping for single-page profiles

### DIFF
--- a/ososedki_dl/crawlers/other/eromexxx.py
+++ b/ososedki_dl/crawlers/other/eromexxx.py
@@ -56,24 +56,11 @@ class EromeXXXCrawler(BaseCrawler):
         if not soup:
             return []
 
-        # Get the total number of albums
-        header: Tag | NavigableString | None = soup.find("div", class_="header-title")
-        if not header:
-            return []
-        span: Tag | NavigableString | None | int = header.find("span")
-        if not span or isinstance(span, int):
-            return []
-        total_albums = int(span.get_text(strip=True))
-        print(f"Total_albums: {total_albums}")
-
-        # Get pagination items
-        pagination: Tag | NavigableString | None = soup.find("ul", class_="pagination")
-        if not pagination or isinstance(pagination, NavigableString):
-            return []
-
-        # Get the last page number
         try:
-            last_page = int(pagination.find_all("li")[-2].text)
+            # Get pagination items
+            pagination: Tag | NavigableString | None = soup.find("ul", class_="pagination")
+            # Get the last page number
+            last_page = int(pagination.find_all("li")[-2].get_text(strip=True))
         except AttributeError:
             # Only one page, return the current page
             last_page = 1


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->

Closes #217

## 📑 Description

<!-- Add a brief description of the pr -->

The update ensures that the crawler correctly scrapes media from profiles with only one page by removing the unnecessary album count check and adjusting the pagination logic. This change addresses the issue where no media was downloaded when a profile contained all content on a single page.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks

<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->

- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

<img alt="{3B3F0C8C-B5E1-4EDA-9228-4877F164FBEC}" src="https://github.com/user-attachments/assets/2696cbf0-3316-4766-b975-1af51dc5f816" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the eromexxx crawler by gracefully handling missing or irregular pagination, defaulting to a single page when needed.
  * Stabilized last-page detection to reduce errors on pages with unexpected structures.
  * Removed reliance on header-based album counts to prevent failures when headers are absent.
  * Ensured uninterrupted media collection across available pages even when page metadata is incomplete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->